### PR TITLE
fix: Enable compilation with newer versions of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # > cmake --build . --target install
 
 PROJECT(libgit2 C)
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.6...3.28)
 
 # Build options
 #


### PR DESCRIPTION
Newer CMake version no longer accepts such old minimum versions.
With this change, require at least 2.6 as before and assume compatibility up to 3.28 (a more modern version used to build the library recently).


Otherwise, you will get this error message:

```
CMake Error at CMakeLists.txt:15 (CMAKE_MINIMUM_REQUIRED):
Compatibility with CMake < 3.5 has been removed from CMake.

Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
to tell CMake that the project requires at least <min> but has been updated
to work with policies introduced by <max> or earlier.

Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway."
```